### PR TITLE
fixed issues on mobile text align and spacing

### DIFF
--- a/src/components/pages/About/style.css
+++ b/src/components/pages/About/style.css
@@ -105,7 +105,7 @@
   .about-uxsociety h2, .about-uxsociety p {
     margin: auto 0;
     padding: 0;
-    text-align: center;
+    text-align: left;
   }
 
   .about-CoreValues {

--- a/src/components/state/Events/style.css
+++ b/src/components/state/Events/style.css
@@ -64,6 +64,7 @@
 }
 
 .AboutHeader {
+  top: 30px;
   font-family: "Proxima Nova", sans-serif;
   color: black;
   letter-spacing: 0;
@@ -76,6 +77,7 @@
   font-weight: lighter;
   line-height: 21px;
   margin-bottom: 45px;
+  margin-top:-12px;
 }
 
 .EventImageMobile {

--- a/src/components/state/Process/style.css
+++ b/src/components/state/Process/style.css
@@ -91,14 +91,14 @@
 
   .MethodBlock {
     margin-top: 30px !important;
-    text-align: center;
+    text-align: left;
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
         -ms-flex-direction: column;
             flex-direction: column;
   }
   .method-subheader {
-    text-align: center;
+    text-align: left;
   }
 }
 

--- a/src/components/stateless/AboutBox/AboutBox.js
+++ b/src/components/stateless/AboutBox/AboutBox.js
@@ -22,7 +22,7 @@ const AboutBox = (props) => {
     font-family: Proxima Nova, sans-serif;
     line-height: normal;
     font-size: 16px;
-    text-align: center;
+    text-align: left;
     letter-spacing: 0.32em;
     color: #B3BCC4;
   `
@@ -34,7 +34,7 @@ const AboutBox = (props) => {
   color: #101010;
 
   @media (max-width: 768px) {
-    text-align: center;
+    text-align: left;
   }
   `
 

--- a/src/components/stateless/AboutValues/LeftValues.js
+++ b/src/components/stateless/AboutValues/LeftValues.js
@@ -15,7 +15,7 @@ const LeftValues = props => {
 
     @media (max-width: 1024px) {
       flex-direction: column-reverse;
-      text-align: center;
+      text-align: left;
 
       img {
         margin: 15px auto !important;

--- a/src/components/stateless/AboutValues/RightValues.js
+++ b/src/components/stateless/AboutValues/RightValues.js
@@ -15,7 +15,7 @@ const RightValues = props => {
 
     @media (max-width: 1024px) {
       flex-direction: column-reverse;
-      text-align: center;
+      text-align: left;
 
       img {
         margin: 15px auto !important;


### PR DESCRIPTION
## Description
1. Fixed issues on mobile spacing 

## Pull Request Changes
1. Edited text-align: center to text-align: left in mobile
2. Added margin for the About this event header and description in Community page

## Screenshots (optional)
Take screenshots whenever there are UI changes
<img width="323" alt="sc1" src="https://user-images.githubusercontent.com/38446842/52481209-ccce7400-2be8-11e9-81f1-cb621930dea6.png">
<img width="375" alt="sc2" src="https://user-images.githubusercontent.com/38446842/52481228-d526af00-2be8-11e9-85be-6d3e4f6b4f04.png">
<img width="332" alt="sc3" src="https://user-images.githubusercontent.com/38446842/52481229-d526af00-2be8-11e9-970a-6e7a21034160.png">
<img width="363" alt="sc4" src="https://user-images.githubusercontent.com/38446842/52481230-d5bf4580-2be8-11e9-8b68-58ea807428a7.png">

<img width="260" alt="screen shot 2019-02-07 at 10 12 09 pm" src="https://user-images.githubusercontent.com/38446842/52481263-f5566e00-2be8-11e9-8ce1-992ddf92c6ac.png">
